### PR TITLE
Remove versions of dependent gems in development

### DIFF
--- a/withings_api.gemspec
+++ b/withings_api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'simple_oauth'
 
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
OS Command Injection in Rake · CVE-2020-8130 · GitHub Advisory Database
https://github.com/advisories/GHSA-jppv-gw3r-w3q8